### PR TITLE
build: create release task for pto-scheduler

### DIFF
--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -1,0 +1,2 @@
+skip-check:
+  - CKV_GHA_7

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -2,13 +2,13 @@ on:
   workflow_dispatch:
     inputs:
       project:
-        description: 'The project name. Specify the project relative to the root project.'
+        description: "The project name. Specify the project relative to the root project."
         required: true
         type: choice
         options:
           - pto-scheduler
 
-permissions: { }
+permissions: {}
 
 jobs:
   create-release:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -4,8 +4,11 @@ on:
       project:
         description: 'The project name. Specify the project relative to the root project.'
         required: true
+        type: string
+        options:
+          - 'pto-scheduler'
 
-permissions: {}
+permissions: { }
 
 jobs:
   create-release:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,21 @@
+on:
+  workflow_dispatch:
+    inputs:
+      project:
+        description: 'The project name. Specify the project relative to the root project.'
+        required: true
+
+permissions: {}
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ vars.JAVA_VERSION }}
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Create release
+        run: ./gradlew :${{inputs.project}}:releaseAll

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -4,9 +4,9 @@ on:
       project:
         description: 'The project name. Specify the project relative to the root project.'
         required: true
-        type: string
+        type: choice
         options:
-          - 'pto-scheduler'
+          - pto-scheduler
 
 permissions: { }
 

--- a/monorepo-convention-plugins/settings-convention-plugin/src/main/kotlin/io/github/tacascer/monorepo/settings/MonorepoSettingsPlugin.kt
+++ b/monorepo-convention-plugins/settings-convention-plugin/src/main/kotlin/io/github/tacascer/monorepo/settings/MonorepoSettingsPlugin.kt
@@ -79,7 +79,7 @@ private enum class Tasks(
     LINT("lint", "Run linters in this project", null),
     CHECK("check", "Run tests and integration tests in this project", LINT),
     BUILD("build", "Run tests and assembles this project artifacts", CHECK),
-    RELEASE("release", "Release this project", CHECK),
+    RELEASE("release", "Release this project", null),
     ;
 
     val ciTaskName = "${developerName}All"

--- a/pto-scheduler/build.gradle.kts
+++ b/pto-scheduler/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
-
 plugins {
     id("kotlin-spring-conventions")
     alias(libs.plugins.sonarqube)
@@ -37,7 +35,7 @@ tasks.check {
     dependsOn(tasks.sonar)
 }
 
-tasks.named<BootBuildImage>("bootBuildImage") {
+tasks.bootBuildImage {
     val image = "tacascer/${project.name}"
     imageName = image
     tags = listOf("$image:${project.version}", "$image:latest")
@@ -52,7 +50,9 @@ tasks.named<BootBuildImage>("bootBuildImage") {
     }
 }
 
-tasks.release {}
+tasks.release {
+    dependsOn(tasks.bootBuildImage)
+}
 
 sonar {
     properties {

--- a/pto-scheduler/build.gradle.kts
+++ b/pto-scheduler/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
+
 plugins {
     id("kotlin-spring-conventions")
     alias(libs.plugins.sonarqube)
@@ -34,6 +36,23 @@ tasks.sonar {
 tasks.check {
     dependsOn(tasks.sonar)
 }
+
+tasks.named<BootBuildImage>("bootBuildImage") {
+    val image = "tacascer/${project.name}"
+    imageName = image
+    tags = listOf("$image:${project.version}", "$image:latest")
+    if (System.getenv("DOCKER_HUB_TOKEN") != null) {
+        publish = true
+        docker {
+            publishRegistry {
+                username = "tacascer"
+                password = System.getenv("DOCKER_HUB_TOKEN")
+            }
+        }
+    }
+}
+
+tasks.release {}
 
 sonar {
     properties {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a manual GitHub Actions workflow for creating releases, allowing users to specify project names.
	- Added a new task for building Docker images, which includes tagging and optional publishing to Docker Hub.

- **Bug Fixes**
	- Updated the release process to allow execution independently of previous checks.

- **Chores**
	- Added a configuration entry to skip a specific linting check during the CI/CD process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->