### PR TITLE
chore: remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-pto-scheduler/  @LowkeyLab/pto-scheduler
-*.gradle.kts    @LowkeyLab/build-eng
-gradle/         @LowkeyLab/build-eng
-.github/        @LowkeyLab/build-eng
-monorepo-convention-plugins/   @LowkeyLab/build-eng


### PR DESCRIPTION
The CODEOWNERS file has been deleted as it is no longer needed. This change helps streamline repository management and reduce unnecessary maintenance.