### PR TITLE
docs: update README with Maven badge and latest dependency @tacascer

### DIFF
--- a/free-dsl/README.md
+++ b/free-dsl/README.md
@@ -25,8 +25,8 @@ a clean, type-safe DSL syntax for constructing instances of your classes.
 
 ```kotlin
 dependencies {
-    implementation("com.github.lowkeylab:free-dsl:latest.release")
-    ksp("com.github.lowkeylab:free-dsl:latest.release")
+    implementation("com.github.lowkeylab:free-dsl-core:latest.release")
+    ksp("com.github.lowkeylab:free-dsl-core:latest.release")
 }
 ```
 

--- a/free-dsl/README.md
+++ b/free-dsl/README.md
@@ -2,6 +2,8 @@
 
 ## Overview
 
+![Maven Central Version](https://img.shields.io/maven-central/v/io.github.lowkeylab/free-dsl-core)
+
 Free-DSL is a Kotlin Multiplatform library that generates idiomatic Kotlin DSL
 builders for data classes and regular classes with primary constructors.
 It uses Kotlin Symbol Processing (KSP) to generate extension functions and
@@ -23,8 +25,8 @@ a clean, type-safe DSL syntax for constructing instances of your classes.
 
 ```kotlin
 dependencies {
-    implementation("com.github.lowkeylab:free-dsl:0.0.1")
-    ksp("com.github.lowkeylab:free-dsl:0.0.1")
+    implementation("com.github.lowkeylab:free-dsl:latest.release")
+    ksp("com.github.lowkeylab:free-dsl:latest.release")
 }
 ```
 
@@ -61,7 +63,8 @@ class RegularClass(
 
 ### 3. Build your project
 
-The KSP processor will generate DSL builder code for your annotated classes (both data classes and regular classes with primary constructors).
+The KSP processor will generate DSL builder code for your annotated classes (
+both data classes and regular classes with primary constructors).
 
 ### 4. Use the generated DSL
 
@@ -91,7 +94,8 @@ val regularClass = regularClass {
 
 ## How It Works
 
-When you annotate a data class or a regular class with a primary constructor with `@FreeDsl`, the KSP processor generates:
+When you annotate a data class or a regular class with a primary constructor
+with `@FreeDsl`, the KSP processor generates:
 
 1. A builder class for your annotated class
 2. Properties in the builder for each constructor parameter


### PR DESCRIPTION
This pull request includes several updates to the `free-dsl/README.md` file to improve documentation and ensure the latest version of dependencies is used.

Documentation updates:

* Added a Maven Central version badge to the top of the README for quick reference to the latest version.
* Updated the dependency version in the example `dependencies` block to always use the latest release.
* Improved readability by splitting long lines in the "Build your project" and "How It Works" sections. [[1]](diffhunk://#diff-03115e5ab5a0320b0ea25ca9f1f7d14b589b3ca79d154dbb2873a2407aa5495dL64-R67) [[2]](diffhunk://#diff-03115e5ab5a0320b0ea25ca9f1f7d14b589b3ca79d154dbb2873a2407aa5495dL94-R98)