### PR TITLE
docs: expand README with project details and build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,86 @@
 # gradle-monorepo
 
-Gradle Monorepo
+A Gradle monorepo containing multiple projects, each with its own build and
+configuration.
+
+## Projects
+
+### [free-dsl](free-dsl/README.md)
+
+A Kotlin Multiplatform library that generates idiomatic Kotlin DSL builders for
+data classes and regular classes with primary constructors.
+It uses Kotlin Symbol Processing (KSP) to generate extension functions and
+builder classes that enable a clean, type-safe DSL syntax.
+
+### guess-the-word
+
+A Spring Boot application that uses MongoDB for data storage, WebSockets for
+real-time communication, and provides a web interface.
+It includes OpenAPI documentation and is containerized with Docker.
+
+### kotlinx-serialization-ber
+
+A Kotlin Multiplatform library for encoding and decoding BER (Basic Encoding
+Rules) data. It uses kotlinx-serialization and is published to Maven Central.
+
+### monorepo-convention-plugins
+
+A collection of Gradle convention plugins used by the monorepo.
+It includes internal convention plugins and a settings convention plugin.
+
+### predix
+
+A Spring Boot application that uses JPA for data access, PostgreSQL as the
+database, and Liquibase for database migrations.
+It includes a web interface with OpenAPI documentation and uses MapStruct for
+object mapping.
+
+### pto-scheduler
+
+A Spring Boot application for PTO (Paid Time Off) scheduling.
+It uses JPA for data access, PostgreSQL as the database,
+Liquibase for database migrations, and has both a web interface and WebFlux for
+reactive programming.
+It includes OpenAPI documentation and is containerized with Docker.
+
+## Building the Monorepo
+
+This monorepo uses Gradle's composite build feature, where each project is
+included as a separate build. To build the entire monorepo:
+
+```bash
+./gradlew build
+```
+
+To build a specific project:
+
+```bash
+./gradlew :projectName:build
+```
+
+For example:
+
+```bash
+./gradlew :free-dsl:build
+```
+
+## Running Tests
+
+To run tests for the entire monorepo:
+
+```bash
+./gradlew test
+```
+
+To run tests for a specific project:
+
+```bash
+./gradlew :projectName:test
+```
+
+## Other Common Tasks
+
+- Run linters: `./gradlew lint`
 
 ## Contribution Guidelines
 


### PR DESCRIPTION
This pull request includes significant updates to the `README.md` file to provide a comprehensive overview of the Gradle monorepo and its projects. The most important changes include detailed descriptions of each project within the monorepo, instructions for building the monorepo, and guidelines for running tests and other common tasks.

Documentation improvements:

* Added descriptions for each project in the monorepo, including `free-dsl`, `guess-the-word`, `kotlinx-serialization-ber`, `monorepo-convention-plugins`, `predix`, and `pto-scheduler`.
* Included instructions for building the entire monorepo and individual projects using Gradle's composite build feature.
* Provided guidelines for running tests for the entire monorepo and specific projects.
* Added a section for other common tasks, such as running linters.Added descriptions for all projects in the monorepo, along with instructions for building, testing, and common tasks. This improves clarity for new contributors and users of the repository.