### PR TITLE
docs: fix Maven Central badge to include clickable link

### DIFF
--- a/free-dsl/README.md
+++ b/free-dsl/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-![Maven Central Version](https://img.shields.io/maven-central/v/io.github.lowkeylab/free-dsl-core)
+[![Maven Central Version](https://img.shields.io/maven-central/v/io.github.lowkeylab/free-dsl-core)](https://central.sonatype.com/artifact/io.github.lowkeylab/free-dsl-core)
 
 Free-DSL is a Kotlin Multiplatform library that generates idiomatic Kotlin DSL
 builders for data classes and regular classes with primary constructors.


### PR DESCRIPTION
Updated the Maven Central badge in the README to be a clickable link pointing to the artifact's page on Sonatype. This improves ease of navigation for users seeking more details about the library.